### PR TITLE
LF-41146 read_csv option to coerce floats while parsing file

### DIFF
--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1050,7 +1050,6 @@ cdef class TextReader:
                     elif i in self.dtype:
                         col_dtype = self.dtype[i]
                     col_dtype, col_coerce_float = dtype_coerce(col_dtype)
-                    print(col_dtype, col_coerce_float)
                 else:
                     if self.dtype.names:
                         # structured array

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -474,8 +474,13 @@ cdef class TextReader:
             self.parser.double_converter = xstrtod
 
         if isinstance(dtype, dict):
-            dtype = {k: pandas_dtype(dtype[k])
-                     for k in dtype}
+            for col, col_dtype in dtype.items():
+                if isinstance(col_dtype, tuple):
+                    col_dtype, coerce = col_dtype
+                    col_dtype = (pandas_dtype(col_dtype), coerce)
+                else:
+                    col_dtype = pandas_dtype(col_dtype)
+                dtype[col] = col_dtype
         elif dtype is not None:
             dtype = pandas_dtype(dtype)
 
@@ -1040,12 +1045,18 @@ cdef class TextReader:
             conv = self._get_converter(i, name)
 
             col_dtype = None
+            col_coerce_float = False
             if self.dtype is not None:
                 if isinstance(self.dtype, dict):
                     if name in self.dtype:
                         col_dtype = self.dtype[name]
                     elif i in self.dtype:
                         col_dtype = self.dtype[i]
+                    if isinstance(col_dtype, tuple):
+                        col_dtype, coerce = col_dtype
+                        col_coerce_float = coerce == 'coerce'
+                        if not is_float_dtype(col_dtype) and col_coerce_float:
+                            raise ValueError('Can only coerce when dtype is a float type')
                 else:
                     if self.dtype.names:
                         # structured array
@@ -1083,7 +1094,7 @@ cdef class TextReader:
             try:
                 col_res, na_count = self._convert_tokens(
                     i, start, end, name, na_filter, na_hashset,
-                    na_flist, col_dtype)
+                    na_flist, col_dtype, col_coerce_float)
             finally:
                 # gh-21353
                 #
@@ -1109,12 +1120,12 @@ cdef class TextReader:
     cdef inline _convert_tokens(self, Py_ssize_t i, int start, int end,
                                 object name, bint na_filter,
                                 kh_str_starts_t *na_hashset,
-                                object na_flist, object col_dtype):
+                                object na_flist, object col_dtype, bint coerce_float):
 
         if col_dtype is not None:
             col_res, na_count = self._convert_with_dtype(
                 col_dtype, i, start, end, na_filter,
-                1, na_hashset, na_flist)
+                1, na_hashset, na_flist, coerce_float)
 
             # Fallback on the parse (e.g. we requested int dtype,
             # but its actually a float).
@@ -1128,7 +1139,8 @@ cdef class TextReader:
             for dt in self.dtype_cast_order:
                 try:
                     col_res, na_count = self._convert_with_dtype(
-                        dt, i, start, end, na_filter, 0, na_hashset, na_flist)
+                        dt, i, start, end, na_filter, 0, na_hashset, na_flist,
+                        coerce_float)
                 except ValueError:
                     # This error is raised from trying to convert to uint64,
                     # and we discover that we cannot convert to any numerical
@@ -1136,11 +1148,11 @@ cdef class TextReader:
                     # column AS IS with object dtype.
                     col_res, na_count = self._convert_with_dtype(
                         np.dtype('object'), i, start, end, 0,
-                        0, na_hashset, na_flist)
+                        0, na_hashset, na_flist, 0)
                 except OverflowError:
                     col_res, na_count = self._convert_with_dtype(
                         np.dtype('object'), i, start, end, na_filter,
-                        0, na_hashset, na_flist)
+                        0, na_hashset, na_flist, 0)
 
                 if col_res is not None:
                     break
@@ -1169,7 +1181,8 @@ cdef class TextReader:
                              bint na_filter,
                              bint user_dtype,
                              kh_str_starts_t *na_hashset,
-                             object na_flist):
+                             object na_flist,
+                             bint coerce_float):
         if is_categorical_dtype(dtype):
             # TODO: I suspect that _categorical_convert could be
             # optimized when dtype is an instance of CategoricalDtype
@@ -1218,7 +1231,7 @@ cdef class TextReader:
 
         elif is_float_dtype(dtype):
             result, na_count = _try_double(self.parser, i, start, end,
-                                           na_filter, na_hashset, na_flist)
+                                           na_filter, na_hashset, na_flist, coerce_float)
 
             if result is not None and dtype != 'float64':
                 result = result.astype(dtype)
@@ -1639,7 +1652,8 @@ cdef:
 
 cdef _try_double(parser_t *parser, int64_t col,
                  int64_t line_start, int64_t line_end,
-                 bint na_filter, kh_str_starts_t *na_hashset, object na_flist):
+                 bint na_filter, kh_str_starts_t *na_hashset, object na_flist,
+                 bint coerce_float):
     cdef:
         int error, na_count = 0
         Py_ssize_t i, lines
@@ -1661,7 +1675,7 @@ cdef _try_double(parser_t *parser, int64_t col,
         error = _try_double_nogil(parser, parser.double_converter,
                                   col, line_start, line_end,
                                   na_filter, na_hashset, use_na_flist,
-                                  na_fset, NA, data, &na_count)
+                                  na_fset, NA, data, &na_count, coerce_float)
 
     kh_destroy_float64(na_fset)
     if error != 0:
@@ -1678,7 +1692,7 @@ cdef inline int _try_double_nogil(parser_t *parser,
                                   bint use_na_flist,
                                   const kh_float64_t *na_flist,
                                   float64_t NA, float64_t *data,
-                                  int *na_count) nogil:
+                                  int *na_count, bint coerce_float) nogil:
     cdef:
         int error = 0,
         Py_ssize_t i, lines = line_end - line_start
@@ -1712,6 +1726,9 @@ cdef inline int _try_double_nogil(parser_t *parser,
                     elif (strcasecmp(word, cneginf) == 0 or
                             strcasecmp(word, cneginfty) == 0 ):
                         data[0] = NEGINF
+                    elif coerce_float:
+                        na_count[0] += 1
+                        data[0] = NA
                     else:
                         return 1
                 if use_na_flist:
@@ -1736,6 +1753,9 @@ cdef inline int _try_double_nogil(parser_t *parser,
                 elif (strcasecmp(word, cneginf) == 0 or
                         strcasecmp(word, cneginfty) == 0):
                     data[0] = NEGINF
+                elif coerce_float:
+                    na_count[0] += 1
+                    data[0] = NA
                 else:
                     return 1
             data += 1

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1889,3 +1889,30 @@ def pandas_dtype(dtype):
         raise TypeError(f"dtype '{dtype}' not understood")
 
     return npdtype
+
+
+def dtype_coerce(dtype):
+    """
+    Determine whether this dtype should be coerced.
+
+    Parameters
+    ----------
+    dtype : object or tuple to be checked
+
+    Returns
+    -------
+    dtype : np.dtype or a pandas dtype
+    coerce : bool
+        Should the dtype be coerced
+
+    Raises
+    ------
+    ValueError if coercion for the dtype is not supported
+    """
+    if isinstance(dtype, tuple):
+        dtype, coerce = dtype
+        if not is_float_dtype(dtype) or coerce != "coerce":
+            raise ValueError('Only "coerce" is supported when dtype is a float type')
+        return dtype, True
+    else:
+        return dtype, False

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -3441,7 +3441,7 @@ def _get_empty_meta(columns, index_col, index_names, dtype=None):
         # Convert column indexes to column names.
         for k, v in _dtype.items():
             col = columns[k] if is_integer(k) else k
-            dtype[col] = v
+            dtype[col] = v[0] if isinstance(v, tuple) else v
 
     # Even though we have no data, the "index" of the empty DataFrame
     # could for example still be an empty MultiIndex. Thus, we need to

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -30,6 +30,7 @@ from pandas.util._decorators import Appender
 
 from pandas.core.dtypes.cast import astype_nansafe
 from pandas.core.dtypes.common import (
+    dtype_coerce,
     ensure_object,
     ensure_str,
     is_bool_dtype,
@@ -38,7 +39,6 @@ from pandas.core.dtypes.common import (
     is_extension_array_dtype,
     is_file_like,
     is_float,
-    is_float_dtype,
     is_integer,
     is_integer_dtype,
     is_list_like,
@@ -1665,11 +1665,7 @@ class ParserBase:
             coerce_float = False
             if isinstance(dtypes, dict):
                 cast_type = dtypes.get(c, None)
-                if isinstance(cast_type, tuple):
-                    cast_type, coerce = cast_type
-                    coerce_float = coerce == "coerce"
-                    if coerce_float and not is_float_dtype(cast_type):
-                        raise ValueError("Can only coerce when dtype is a float type")
+                cast_type, coerce_float = dtype_coerce(cast_type)
             else:
                 # single dtype or None
                 cast_type = dtypes

--- a/pandas/tests/io/parser/test_dtypes.py
+++ b/pandas/tests/io/parser/test_dtypes.py
@@ -562,25 +562,16 @@ def test_dtype_coerce(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
-def test_dtype_coerce_with_int_raises(all_parsers):
+@pytest.mark.parametrize(
+    "dtype", [{"a": (float, "coerce"), "b": (int, "coerce")}, {"a": (float, "fail")}]
+)
+def test_dtype_coerce_invalid_args_raises(all_parsers, dtype):
     parser = all_parsers
     data = """a,b\n1,2\na,3"""
-    with pytest.raises(ValueError, match="Can only coerce when dtype is a float type"):
-        parser.read_csv(
-            StringIO(data), dtype={"a": (float, "coerce"), "b": (int, "coerce")}
-        )
-
-
-def test_dtype_coerce_invalid_name_raises(all_parsers):
-    parser = all_parsers
-    data = """a,b\n1,2\na,3"""
-    msg = (
-        "could not convert string to float: 'a'"
-        if parser.engine == "c"
-        else "Unable to convert column a to type <class 'float'>"
-    )
-    with pytest.raises(ValueError, match=msg):
-        parser.read_csv(StringIO(data), dtype={"a": (float, "fail")})
+    with pytest.raises(
+        ValueError, match='Only "coerce" is supported when dtype is a float type'
+    ):
+        parser.read_csv(StringIO(data), dtype=dtype)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/io/parser/test_dtypes.py
+++ b/pandas/tests/io/parser/test_dtypes.py
@@ -574,6 +574,14 @@ def test_dtype_coerce_invalid_args_raises(all_parsers, dtype):
         parser.read_csv(StringIO(data), dtype=dtype)
 
 
+def test_dtype_coerce_empty(all_parsers):
+    parser = all_parsers
+    data = """a,b"""
+    result = parser.read_csv(StringIO(data), dtype={"a": (float, "coerce"), "b": float})
+    expected = DataFrame([], columns=["a", "b"], dtype=float)
+    tm.assert_frame_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "na_values,expected",
     [


### PR DESCRIPTION
This PR adds a mechanism that coerces strings that cannot be converted to floats as nans. Typically there is a two step process of reading the file as strings and then converting to floats. This PR combines those two steps and yields 5x speed improvement for large files.

The calling syntax: `read_csv(filename, dtype={'colname': (float, 'coerce')})` as described in issue https://github.com/pandas-dev/pandas/issues/2570.